### PR TITLE
Fixed typographical error, changed aganist to against in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This module adds some protection aganist poison null bytes to the native "fs" module. To activate it, just put this at the top of your main application file:
+This module adds some protection against poison null bytes to the native "fs" module. To activate it, just put this at the top of your main application file:
 
     require('protect-fs')
 


### PR DESCRIPTION
@thejh, I've corrected a typographical error in the documentation of the [node-protect-fs](https://github.com/thejh/node-protect-fs) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository. 
